### PR TITLE
Import source map package in a ES6 way

### DIFF
--- a/es6/myapp.js
+++ b/es6/myapp.js
@@ -1,5 +1,4 @@
-import { install } from 'source-map-support';
-install();
+import 'source-map-support/register';
 
 import 'babel-polyfill';
 


### PR DESCRIPTION
According to the [source-map-support documentation](https://github.com/evanw/node-source-map-support) we can do this:

> It is also possible to to install the source map support directly by requiring the register module which can be handy with ES6:

``` javascript
import 'source-map-support/register'
```

``` javascript
// Instead of:
import sourceMapSupport from 'source-map-support'
sourceMapSupport.install()
```

> It is also very useful with Mocha:

``` javascript
$ mocha --require source-map-support/register tests/
```
